### PR TITLE
Add homebrew implementation of std::monotonic_buffer_resource

### DIFF
--- a/main/src/monotonic_buffer_resource.cc
+++ b/main/src/monotonic_buffer_resource.cc
@@ -1,0 +1,37 @@
+#include "monotonic_buffer_resource.hh"
+
+void * // NOLINTNEXTLINE(modernize-use-trailing-return-type)
+MonotonicBufferResource::do_allocate(std::size_t bytes, std::size_t alignment)
+{
+    auto const
+        align_diff = // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        (alignment - reinterpret_cast<uintptr_t>(data_) % alignment) %
+        alignment;
+    auto const alloc_size = bytes + align_diff;
+    if (alloc_size > size_) {
+        return nullptr;
+    }
+
+    auto * const alloc_base = data_ + align_diff;
+    data_ += alloc_size;
+    size_ -= alloc_size;
+    return alloc_base;
+}
+
+void // NOLINTNEXTLINE(modernize-use-trailing-return-type)
+MonotonicBufferResource::do_deallocate(void *      p,
+                                       std::size_t bytes,
+                                       std::size_t alignment)
+{
+    (void)p;
+    (void)bytes;
+    (void)alignment;
+}
+
+bool // NOLINTNEXTLINE(modernize-use-trailing-return-type)
+MonotonicBufferResource::do_is_equal(
+    const std::pmr::memory_resource & other) const noexcept
+{
+    (void)other;
+    return false;
+}

--- a/main/src/monotonic_buffer_resource.hh
+++ b/main/src/monotonic_buffer_resource.hh
@@ -1,0 +1,26 @@
+#ifndef MONOTONIC_BUFFER_RESOURCE_HH
+#define MONOTONIC_BUFFER_RESOURCE_HH
+
+#include <cstddef>
+#include <cstdint>
+#include <memory_resource>
+
+class MonotonicBufferResource final : public std::pmr::memory_resource {
+    std::byte * data_;
+    size_t      size_;
+
+    void * // NOLINTNEXTLINE(modernize-use-trailing-return-type)
+    do_allocate(std::size_t bytes, std::size_t alignment) final;
+    void // NOLINTNEXTLINE(modernize-use-trailing-return-type)
+    do_deallocate(void * p, std::size_t bytes, std::size_t alignment) final;
+    bool // NOLINTNEXTLINE(modernize-use-trailing-return-type)
+    do_is_equal(const std::pmr::memory_resource & other) const noexcept final;
+
+public:
+    MonotonicBufferResource(std::byte * data, size_t size)
+        : data_{data}, size_{size}
+    {
+    }
+};
+
+#endif


### PR DESCRIPTION
Clang still doesn't support it and it's nice to have